### PR TITLE
#166731793 Admin can delete posted car Ad(s)

### DIFF
--- a/src/controllers/cars.js
+++ b/src/controllers/cars.js
@@ -275,6 +275,42 @@ class CarAds {
       data: 'Internal Server Error',
     });
   }
+
+  static async deleteAd(req, res) {
+    const { is_admin } = req.authData.user;
+
+    if (is_admin) {
+      const id = parseInt(req.params.id, 10);
+
+      try {
+        const result = await DB.query(`DELETE FROM cars WHERE id = '${id}'`);
+
+        if (result.rowCount === 0) {
+          return res.status(200).json({
+            status: 200,
+            data: 'No record found',
+          });
+        }
+
+        return res.status(200).json({
+          status: 200,
+          data: 'Car Ad successfully deleted',
+        });
+      } catch (err) {
+        warn(err);
+
+        return res.status(200).json({
+          status: 200,
+          data: 'No record found',
+        });
+      }
+    }
+
+    return res.status(403).json({
+      status: 403,
+      error: 'Forbidden: Only Admin can delete an AD',
+    });
+  }
 }
 
 export default CarAds;

--- a/src/routes/cars.js
+++ b/src/routes/cars.js
@@ -12,5 +12,6 @@ Route.patch('/car/:id/status', checkAuth, validate.Status, carController.updateS
 Route.patch('/car/:id/price', checkAuth, validate.Price, carController.updateCarPrice);
 Route.get('/car/:id', checkAuth, carController.findSpecificCar);
 Route.get('/car/', checkAuth, carController.find);
+Route.delete('/car/:id', checkAuth, carController.deleteAd);
 
 export default Route;

--- a/src/tests/cars.js
+++ b/src/tests/cars.js
@@ -970,6 +970,30 @@ describe('Test for car AD endpoint', () => {
       });
   });
 
+  it('Should return an error if  ID is bad', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/car/123456g')
+      .set({
+        'Content-type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        Authorization: adminToken,
+      })
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.be.equal('No record found');
+        expect(res.body.data).to.be.a('string');
+        assert.isObject(res.body, 'Response is not an object');
+        assert.strictEqual(res.statusCode, 200, 'Status code is not 200');
+        assert.isString(res.body.data, 'Data is not a string');
+        assert.strictEqual(res.body.data,
+          'No record found',
+          'Data is not equal to No record found');
+        assert.isNull(err, 'Expect error to not exist');
+        done();
+      });
+  });
   it('Should return an error if user is not an admin', (done) => {
     chai
       .request(app)

--- a/src/tests/cars.js
+++ b/src/tests/cars.js
@@ -10,6 +10,7 @@ import app from '../app';
 chai.use(chaiHttp);
 
 const token = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoxMTMyNjc1NDYwLCJmaXJzdG5hbWUiOiJQYXVsIiwibGFzdG5hbWUiOiJUYWl3byIsImVtYWlsIjoiYXlvcGF1bG90QGdtYWlsLmNvbSIsImFkZHJlc3MiOiIxMiwgQWRlcmliaWdiZSIsImlzX2FkbWluIjpmYWxzZX0sImlhdCI6MTU2MDk0NjU0NiwiZXhwIjoxNTYxMTkxMzQ2fQ.BmqvWXxsR67XG6hePl7bsnj_bXM62sKWNbMnqBYbzQo';
+const adminToken = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoxMTMyNjc1NDYwLCJmaXJzdG5hbWUiOiJQYXVsIiwibGFzdG5hbWUiOiJUYWl3byIsImVtYWlsIjoiYXlvcGF1bG90YUBnbWFpbC5jb20iLCJhZGRyZXNzIjoiMTIsIEFkZXJpYmlnYmUiLCJpc19hZG1pbiI6dHJ1ZX0sImlhdCI6MTU2MTA0MDI4NywiZXhwIjoxNTYxMjg1MDg3fQ.f4pnNPQdWOUNQsH9AZXa6WOBQw46-TJU2dJPJ0d95TY';
 const invalidToken = 'Bearer engaF1bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoxMTMyNjc1NDYwLCJmaXJzdG5hbWUiOiJQYXVsIiwibGFzdG5hbWUiOiJUYWl3byIsImVtYWlsIjoiYXlvcGF1bG90QGdtYWlsLmNvbSIsImFkZHJlc3MiOiIxMiwgQWRlcmliaWdiZSIsImlzX2FkbWluIjpmYWxzZX0sImlhdCI6MTU2MDk0NjU0NiwiZXhwIjoxNTYxMTkxMzQ2fQ.BmqvWXxsR67XG6hePl7bsnj_bXM62sKWNbMnqBYbzQo';
 const file = readFileSync('src/test-img/car.png');
 const file2 = readFileSync('src/test-img/car2.jpg');
@@ -914,6 +915,81 @@ describe('Test for car AD endpoint', () => {
         assert.strictEqual(res.body.data,
           'No record found',
           'Data is not equal to No record found');
+        assert.isNull(err, 'Expect error to not exist');
+        done();
+      });
+  });
+
+  it('Should delete an AD if user is an admin', (done) => {
+    chai
+      .request(app)
+      .delete(`/api/v1/car/${carAd.id}`)
+      .set({
+        'Content-type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        Authorization: adminToken,
+      })
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.be.equal('Car Ad successfully deleted');
+        expect(res.body.data).to.be.a('string');
+        assert.isObject(res.body, 'Response is not an object');
+        assert.strictEqual(res.statusCode, 200, 'Status code is not 200');
+        assert.isString(res.body.data, 'Data is not a string');
+        assert.strictEqual(res.body.data,
+          'Car Ad successfully deleted',
+          'Data is not equal to Car Ad successfully deleted');
+        assert.isNull(err, 'Expect error to not exist');
+        done();
+      });
+  });
+
+  it('Should return a message if record is not found', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/car/11111045')
+      .set({
+        'Content-type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        Authorization: adminToken,
+      })
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.be.equal('No record found');
+        expect(res.body.data).to.be.a('string');
+        assert.isObject(res.body, 'Response is not an object');
+        assert.strictEqual(res.statusCode, 200, 'Status code is not 200');
+        assert.isString(res.body.data, 'Data is not a string');
+        assert.strictEqual(res.body.data,
+          'No record found',
+          'Data is not equal to No record found');
+        assert.isNull(err, 'Expect error to not exist');
+        done();
+      });
+  });
+
+  it('Should return an error if user is not an admin', (done) => {
+    chai
+      .request(app)
+      .delete(`/api/v1/car/${carAd.id}`)
+      .set({
+        'Content-type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        Authorization: token,
+      })
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(403);
+        expect(res.body).to.be.an('object');
+        expect(res.body.error).to.be.equal('Forbidden: Only Admin can delete an AD');
+        expect(res.body.error).to.be.a('string');
+        assert.isObject(res.body, 'Response is not an object');
+        assert.strictEqual(res.statusCode, 403, 'Status code is not 403');
+        assert.isString(res.body.error, 'Data is not a string');
+        assert.strictEqual(res.body.error,
+          'Forbidden: Only Admin can delete an AD',
+          'Error is not equal to Forbidden: Only Admin can delete an AD');
         assert.isNull(err, 'Expect error to not exist');
         done();
       });

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -46,4 +46,24 @@ describe('Test API v1 Endpoint', () => {
         done();
       });
   });
+
+  it('should return the API doc page', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/docs')
+      .set({
+        'Content-Type': 'multipart/form-data',
+        Accept: 'application/json',
+      })
+      .end((err, res) => {
+        expect(res.type).to.be.a('string');
+        expect(res.statusCode).to.equal(200);
+        expect(res.ok).to.equal(true);
+        assert.strictEqual(res.type, 'text/html', 'Expect response to be a string');
+        assert.strictEqual(res.statusCode, 200, 'Status code should be 200');
+        assert.strictEqual(res.ok, true, 'Status message should be OK');
+        assert.isNull(err, 'Expect error to not exist');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Admin can delete a posted AD record

#### Description of Task to be completed?
- Have the following endpoint working
   - `DELETE api/v1/car/<:car_id>`
- Implement token-based authentication using JSON Web Token (JWT)
- Secure endpoint

#### How should this be manually tested?
- Make sure you have `node.js` installed and have set up a database 
   Check [here](https://www.guru99.com/postgresql-create-database.htmll) for how to set up a PostgreSQL database
- Clone or fork the repository
- CD into `automart`
- Checkout to `develop` branch
- Run `npm install` to install dependencies
- Run `npm db:migrate` to create tables in the database
- Then run `npm run dev` to start the server
- Test Endpoint with Postman

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#166731793](https://www.pivotaltracker.com/story/show/166731793)